### PR TITLE
Fix wrongly disabling static key (for xdp locking)

### DIFF
--- a/src/ixgbe_lib.c
+++ b/src/ixgbe_lib.c
@@ -1124,10 +1124,7 @@ static void ixgbe_free_q_vector(struct ixgbe_adapter *adapter, int v_idx)
 		else
 			adapter->tx_ring[ring->queue_index] = NULL;
 	}
-
-	if (static_key_enabled((struct static_key *)&ixgbe_xdp_locking_key))
-		static_branch_dec(&ixgbe_xdp_locking_key);
-
+	
 	ixgbe_for_each_ring(ring, q_vector->rx)
 		adapter->rx_ring[ring->queue_index] = NULL;
 


### PR DESCRIPTION
This fixes the wrong decrease in static key "ixgbe_xdp_locking_key", which causes driver to panic if there is some XDP program working along with a TC one, with > 64 CPU cores.