### PR TITLE
Fix build on kernel 6.15.x

### DIFF
--- a/src/ixgbe_main.c
+++ b/src/ixgbe_main.c
@@ -8430,7 +8430,11 @@ void ixgbe_down(struct ixgbe_adapter *adapter)
 	clear_bit(__IXGBE_RESET_REQUESTED, adapter->state);
 	adapter->flags &= ~IXGBE_FLAG_NEED_LINK_UPDATE;
 
-	del_timer_sync(&adapter->service_timer);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,0)
+        timer_delete_sync(&adapter->service_timer);
+#else
+        del_timer_sync(&adapter->service_timer);
+#endif
 
 	if (adapter->num_vfs) {
 		/* Clear EITR Select mapping */


### PR DESCRIPTION
Name of kernel function changed from del_timer_sync to timer_delete_sync.
I change it based of the kernel version for backwards compatibility.